### PR TITLE
Fix: Resolve Python timeout by explicitly passing environment to spawned process

### DIFF
--- a/src/components/CodeExecutor.ts
+++ b/src/components/CodeExecutor.ts
@@ -225,7 +225,11 @@ while True:
         sys.stdout.flush()
 `;
 
-            this.pythonProcess = spawn(this.plugin.settings.pythonInterpreter, ["-c", initCode]);
+            this.pythonProcess = spawn(
+                this.plugin.settings.pythonInterpreter,
+                ["-c", initCode],
+                { env: { ...process.env } }
+            );
 
             let initOutput = "";
 


### PR DESCRIPTION
This PR fixes a critical bug that causes a `Python process initialization timeout` error, primarily affecting users on macOS who use Conda or Miniforge environments.

When using a Python interpreter from a Conda environment, the plugin fails to initialize the Python process and eventually times out.
#12 


- The Conda environment itself is healthy (`jupyter console` and `python -m jupytext --sync` work perfectly from an activated terminal).
- The issue occurs because the Node.js `spawn` command was being called without explicitly passing the environment variables from the parent process (Obsidian).
- A Conda Python interpreter is not self-contained; it relies on environment variables (especially `PATH`) to locate its own libraries and dependencies. Without these, it fails to start up correctly, leading to the timeout.

This fixes that, and should work for all users on other platforms too, though I have only tested on MacOS.