### PR TITLE
fix: Code blocks are now visible in PDF exports

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,14 @@
-import {Plugin, TFile} from "obsidian";
-import {JupyMDSettingTab} from "./components/Settings";
-import {CodeExecutor} from "./components/CodeExecutor";
-import {FileSync} from "./components/FileSync";
-import {DEFAULT_SETTINGS, JupyMDPluginSettings} from "./components/types";
-import {registerCommands} from "./commands";
+import { Plugin, TFile } from "obsidian";
+import { JupyMDSettingTab } from "./components/Settings";
+import { CodeExecutor } from "./components/CodeExecutor";
+import { FileSync } from "./components/FileSync";
+import { DEFAULT_SETTINGS, JupyMDPluginSettings } from "./components/types";
+import { registerCommands } from "./commands";
 import * as React from "react";
-import {createRoot} from "react-dom/client";
-import {PythonCodeBlock} from "./components/CodeBlock";
-import {getAbsolutePath} from "./utils/helpers";
-import {getDefaultPythonPath} from "./utils/pythonPathUtils";
+import { createRoot } from "react-dom/client";
+import { PythonCodeBlock } from "./components/CodeBlock";
+import { getAbsolutePath } from "./utils/helpers";
+import { getDefaultPythonPath } from "./utils/pythonPathUtils";
 
 export default class JupyMDPlugin extends Plugin {
 	settings: JupyMDPluginSettings;
@@ -19,7 +19,7 @@ export default class JupyMDPlugin extends Plugin {
 	async onload() {
 		await this.loadSettings();
 
-		if(!this.settings.pythonInterpreter) {
+		if (!this.settings.pythonInterpreter) {
 			this.settings.pythonInterpreter = getDefaultPythonPath();
 			await this.saveSettings();
 		}
@@ -41,6 +41,30 @@ export default class JupyMDPlugin extends Plugin {
 		if (this.settings.enableCodeBlocks) {
 			this.registerMarkdownCodeBlockProcessor("python", (source, el, ctx) => {
 				el.empty();
+
+
+
+
+				// Create a container that preserves markdown structure for PDF export
+				const markdownContainer = document.createElement("div");
+				markdownContainer.className = "jupymd-code-block-container";
+				markdownContainer.style.display = "none"; // Hidden from view but accessible to PDF export
+
+				// Preserve original markdown structure
+				const markdownCode = document.createElement("pre");
+				markdownCode.className = "language-python";
+				const markdownCodeEl = document.createElement("code");
+				markdownCodeEl.className = "language-python";
+				markdownCodeEl.textContent = source;
+				markdownCode.appendChild(markdownCodeEl);
+				markdownContainer.appendChild(markdownCode);
+
+				// Add to DOM but keep hidden
+				el.appendChild(markdownContainer);
+
+
+
+
 				const reactRoot = document.createElement("div");
 				el.appendChild(reactRoot);
 
@@ -85,7 +109,7 @@ export default class JupyMDPlugin extends Plugin {
 						}
 					});
 				} else {
-					createRoot(reactRoot).render(<PythonCodeBlock code={source}/>);
+					createRoot(reactRoot).render(<PythonCodeBlock code={source} />);
 				}
 			});
 		}

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,37 @@
 	display: none !important;
 }
 
+/* PDF Export Compatibility Styles */
+.jupymd-code-block-container {
+	display: none !important;
+}
+
+@media print {
+	.jupymd-code-block-container {
+		display: block !important;
+	}
+
+	.jupymd-code-block-container pre {
+		margin: 1em 0;
+		padding: 1em;
+		background-color: #f6f8fa !important;
+		border: 1px solid #d1d9e0 !important;
+		border-radius: 6px;
+		font-family: 'SFMono-Regular', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Consolas', 'Courier New', monospace !important;
+		font-size: 12px !important;
+		line-height: 1.45 !important;
+		overflow: auto;
+		white-space: pre;
+	}
+
+	.jupymd-code-block-container code {
+		font-family: inherit !important;
+		background-color: transparent !important;
+		border: none !important;
+		padding: 0 !important;
+	}
+}
+
 .code-container {
 	border-radius: 6px;
 	overflow: hidden;
@@ -88,4 +119,37 @@
 .code-container .cm-content {
 	border: none;
 	box-shadow: none;
+}
+
+/* Additional PDF export styles for React-rendered code blocks */
+@media print {
+	.code-container {
+		border: 1px solid #d1d9e0 !important;
+		background-color: #f6f8fa !important;
+	}
+
+	.code-container .cm-editor {
+		background-color: #f6f8fa !important;
+		font-family: 'SFMono-Regular', 'Monaco', 'Inconsolata', 'Roboto Mono', 'Consolas', 'Courier New', monospace !important;
+		font-size: 12px !important;
+		line-height: 1.45 !important;
+	}
+
+	.code-container .cm-scroller {
+		background-color: #f6f8fa !important;
+		padding: 1em !important;
+	}
+
+	/* Hide interactive elements in print */
+	.code-top-bar,
+	.icon-button,
+	.code-buttons {
+		display: none !important;
+	}
+
+	.code-output {
+		border-top: 1px solid #d1d9e0 !important;
+		margin-top: 1em !important;
+		padding-top: 1em !important;
+	}
 }


### PR DESCRIPTION
Code blocks will now be visible in PDF exports
#18 

Tried same method but with the output blocks, did not work, help needed