### PR TITLE
Fix sync issues by implementing debouncing and deadtime delays

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "jupymd",
 	"name": "JupyMD",
-	"version": "1.4",
+	"version": "1.4.1",
 	"minAppVersion": "1.8.4",
 	"description": "Use Jupyter notebooks in Obsidian.",
 	"author": "Deniz Terzioglu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jupymd",
-	"version": "1.3",
+	"version": "1.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jupymd",
-			"version": "1.3",
+			"version": "1.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/highlight": "^0.19.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jupymd",
-	"version": "1.1.1",
+	"version": "1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jupymd",
-			"version": "1.1.1",
+			"version": "1.3",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/highlight": "^0.19.8",

--- a/src/components/FileSync.ts
+++ b/src/components/FileSync.ts
@@ -157,6 +157,7 @@ export class FileSync {
 				new Notice(
 					`Failed to open notebook in editor: ${error.message}`
 				);
+				console.error(error)
 				return;
 			}
 			new Notice(`Opened notebook in editor: ${ipynbPath}`);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,14 +1,13 @@
-import {Plugin, TFile} from "obsidian";
-import {JupyMDSettingTab} from "./components/Settings";
-import {CodeExecutor} from "./components/CodeExecutor";
-import {FileSync} from "./components/FileSync";
-import {DEFAULT_SETTINGS, JupyMDPluginSettings} from "./components/types";
-import {registerCommands} from "./commands";
-import * as React from "react";
-import {createRoot} from "react-dom/client";
-import {PythonCodeBlock} from "./components/CodeBlock";
-import {getAbsolutePath} from "./utils/helpers";
-import {getDefaultPythonPath} from "./utils/pythonPathUtils";
+import { Plugin, TFile } from "obsidian";
+import { JupyMDSettingTab } from "./components/Settings";
+import { CodeExecutor } from "./components/CodeExecutor";
+import { FileSync } from "./components/FileSync";
+import { DEFAULT_SETTINGS, JupyMDPluginSettings } from "./components/types";
+import { registerCommands } from "./commands";
+import { createRoot } from "react-dom/client";
+import { PythonCodeBlock } from "./components/CodeBlock";
+import { getAbsolutePath } from "./utils/helpers";
+import { getDefaultPythonPath } from "./utils/pythonPathUtils";
 
 export default class JupyMDPlugin extends Plugin {
 	settings: JupyMDPluginSettings;
@@ -16,10 +15,15 @@ export default class JupyMDPlugin extends Plugin {
 	fileSync: FileSync;
 	currentNotePath: string | null = null;
 
+	private lastSyncTime: number = 0;
+	private syncDebounceTimeout: NodeJS.Timeout | null = null;
+	private readonly SYNC_DEADTIME_MS = 1500;
+	private readonly DEBOUNCE_DELAY_MS = 500;
+
 	async onload() {
 		await this.loadSettings();
 
-		if(!this.settings.pythonInterpreter) {
+		if (!this.settings.pythonInterpreter) {
 			this.settings.pythonInterpreter = getDefaultPythonPath();
 			await this.saveSettings();
 		}
@@ -34,65 +38,101 @@ export default class JupyMDPlugin extends Plugin {
 
 		this.registerEvent(
 			this.app.vault.on("modify", async (file: TFile) => {
-				await this.fileSync.syncFiles(file);
+				console.log("modify");
+				if (this.settings.enableContinuousSync) {
+					await this.handleSync(file);
+				}
 			})
 		);
 
 		if (this.settings.enableCodeBlocks) {
-			this.registerMarkdownCodeBlockProcessor("python", (source, el, ctx) => {
-				el.empty();
-				const reactRoot = document.createElement("div");
-				el.appendChild(reactRoot);
+			this.registerMarkdownCodeBlockProcessor(
+				"python",
+				(source, el, ctx) => {
+					el.empty();
+					const reactRoot = document.createElement("div");
+					el.appendChild(reactRoot);
 
-				const activeFile = this.app.workspace.getActiveFile();
+					const activeFile = this.app.workspace.getActiveFile();
 
-				let index = 0;
-				if (activeFile) {
-					const filePath = getAbsolutePath(activeFile)
-					const fileContent = this.app.vault.read(activeFile);
+					let index = 0;
+					if (activeFile) {
+						const filePath = getAbsolutePath(activeFile);
+						const fileContent = this.app.vault.read(activeFile);
 
-					fileContent.then(content => {
-						const lines = content.split("\n");
-						let blockCount = 0;
-						let foundCurrentBlock = false;
+						fileContent.then((content) => {
+							const lines = content.split("\n");
+							let blockCount = 0;
+							let foundCurrentBlock = false;
 
-						const sectionInfo = ctx.getSectionInfo(el);
-						if (!sectionInfo) return;
+							const sectionInfo = ctx.getSectionInfo(el);
+							if (!sectionInfo) return;
 
-						for (let i = 0; i < lines.length; i++) {
-							const line = lines[i].trim();
-							if (line.startsWith("```python")) {
-								if (i < sectionInfo.lineStart) {
-									blockCount++;
-								} else if (i === sectionInfo.lineStart) {
-									foundCurrentBlock = true;
-									break;
+							for (let i = 0; i < lines.length; i++) {
+								const line = lines[i].trim();
+								if (line.startsWith("```python")) {
+									if (i < sectionInfo.lineStart) {
+										blockCount++;
+									} else if (i === sectionInfo.lineStart) {
+										foundCurrentBlock = true;
+										break;
+									}
 								}
 							}
-						}
 
-						if (foundCurrentBlock) {
-							index = blockCount;
-							createRoot(reactRoot).render(
-								<PythonCodeBlock
-									code={source}
-									path={filePath}
-									index={index}
-									executor={this.executor}
-									plugin={this}
-								/>
-							);
-						}
-					});
-				} else {
-					createRoot(reactRoot).render(<PythonCodeBlock code={source}/>);
+							if (foundCurrentBlock) {
+								index = blockCount;
+								createRoot(reactRoot).render(
+									<PythonCodeBlock
+										code={source}
+										path={filePath}
+										index={index}
+										executor={this.executor}
+										plugin={this}
+									/>
+								);
+							}
+						});
+					} else {
+						createRoot(reactRoot).render(
+							<PythonCodeBlock code={source} />
+						);
+					}
 				}
-			});
+			);
+		}
+	}
+
+	private async handleSync(file: TFile): Promise<void> {
+		if (this.syncDebounceTimeout) {
+			clearTimeout(this.syncDebounceTimeout);
+		}
+		this.syncDebounceTimeout = setTimeout(async () => {
+			await this.deadtimeSync(file);
+		}, this.DEBOUNCE_DELAY_MS);
+	}
+
+	private async deadtimeSync(file: TFile): Promise<void> {
+		const currentTime = Date.now();
+
+		if (currentTime - this.lastSyncTime < this.SYNC_DEADTIME_MS) {
+			console.log("sync request ignored - deadtime");
+			return;
+		}
+
+		try {
+			console.log("start sync");
+			this.lastSyncTime = currentTime;
+			await this.fileSync.syncFiles(file);
+			console.log("sync complete");
+		} catch (error) {
+			console.error(error);
+			this.lastSyncTime = 0;
 		}
 	}
 
 	async onunload() {
-		this.executor.cleanup()
+		this.executor.cleanup();
 	}
 
 	async loadSettings() {


### PR DESCRIPTION
The sync issues addressed in #17 were found to be due to the high frequency of sync calls while editing a file.

## The problem in brief

A file modification triggers two calls to sync instead of one. Due to how Jupytext handles syncing, if a subsequent sync call is made before the initial sync is complete, data loss occurs. Hence, a user's system is not able to complete syncing before the second call to sync is made, data is lost.

## Solution

I believe to have solved this issue by implementing a debounce and deadtime delay:

The debounce delay prevents a sync call from happening while the user is actively modifying the file. This essentially solves the problem of text being removed as the user is typing.

The deadtime delay prevents subsequent sync calls from happening too frequently. This solves the problem of the sync calls being made in pairs.

A minor downside to this implementation is having to delay code execution until the delays are over. Executing code triggers a sync call, which needs to be delayed if a sync process is already happening. This however is only slightly noticeable when the user calls to execute code quickly after modifying the file, and lasts for 5.1 seconds at most.

I have (qualitatively) tested this implementation and all seems well. This should hopefully fully address #17 and put an end to the sync problems.