### PR TITLE
feat: Add 'Embed outputs in Markdown' setting for auto-baking outputs

### DIFF
--- a/src/components/CodeExecutor.ts
+++ b/src/components/CodeExecutor.ts
@@ -1,11 +1,10 @@
 import JupyMDPlugin from "../main";
-import {App, Notice, TFile} from "obsidian";
+import {App, Notice} from "obsidian";
 import {exec} from "child_process";
 import {getAbsolutePath} from "../utils/helpers";
 import {CodeBlock} from "./types";
 import * as fs from "fs/promises";
 import {spawn, ChildProcess} from "child_process";
-
 
 export class CodeExecutor {
     private currentNotePath: string | null = null;

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -102,7 +102,5 @@ export class JupyMDSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 })
             })
-
-
     }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,8 +16,6 @@ export default class JupyMDPlugin extends Plugin {
 	async onload() {
 		await this.loadSettings();
 
-
-
 		if (!this.settings.pythonInterpreter) {
 			this.settings.pythonInterpreter = getDefaultPythonPath();
 			await this.saveSettings();


### PR DESCRIPTION
## Summary

This PR adds a new setting **"Embed outputs in Markdown"** that automatically embeds code outputs directly into the Markdown file after each cell execution.

## Screenshots

- in markdown

<img width="1534" height="580" alt="CleanShot 2026-01-12 at 09 51 18@2x" src="https://github.com/user-attachments/assets/1de1831d-3520-4841-b58f-ff7a8fb2c13d" />

- in exported PDF

<img width="572" height="338" alt="CleanShot 2026-01-12 at 09 51 54@2x" src="https://github.com/user-attachments/assets/6c2508d0-2959-4d43-84d1-c7423df75900" />

## Problem

Closes #18

When exporting notes to PDF or using static site generators like Quartz, code outputs don't appear because they're stored in the paired `.ipynb` file rather than the Markdown itself.

## Solution

### New Setting: "Embed outputs in Markdown"
- Located in Settings → General
- Default: **off** (preserves existing behavior)
- When enabled, outputs are automatically baked into the Markdown after each code execution

### How it works
Outputs are wrapped in HTML comments to keep them invisible in source but rendered in exports:
```markdown
```python
print('hello')
```
<!-- jupymd:output:start -->
```output
hello
```
<!-- jupymd:output:end -->
```

### Manual Commands (still available)
- **"Bake outputs into markdown"** - One-time bake for all cells
- **"Clear baked outputs from markdown"** - Remove all embedded outputs

## Changes
- `src/components/types.ts` - Added `embedOutputs` setting
- `src/components/Settings.ts` - Added toggle in Settings UI  
- `src/components/CodeExecutor.ts` - Auto-bake after execution when enabled
- `src/components/bakeOutputs.ts` - Core baking logic (from previous commits)
- `src/commands.ts` - Manual bake/clear commands