### PR TITLE
Implement python interpreter finder / selector

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,6 +5,12 @@ export function registerCommands(plugin: JupyMDPlugin) {
 	const { executor } = plugin;
 
 	plugin.addCommand({
+		id: "select-python-kernel",
+		name: "Select Python kernel",
+		callback: () => plugin.openKernelSelector(),
+	});
+
+	plugin.addCommand({
 		id: "create-jupyter-notebook",
 		name: "Create Jupyter notebook from note",
 		callback: () => fileSync.createNotebook(),

--- a/src/components/KernelSelector.ts
+++ b/src/components/KernelSelector.ts
@@ -1,0 +1,148 @@
+import {App, FuzzySuggestModal, FuzzyMatch, Notice} from "obsidian";
+import JupyMDPlugin from "../main";
+import {discoverKernels, KernelInfo} from "../utils/kernelDiscovery";
+import {validatePythonPath} from "../utils/pythonPathUtils";
+
+const TYPE_BADGE: Record<KernelInfo["type"], string> = {
+	venv: "venv",
+	system: "system",
+};
+
+type CustomPathOption = {
+	label: string;
+	path: string;
+	version: string;
+	type: "system";
+	isCustomPath: true;
+};
+
+type KernelOption = KernelInfo | CustomPathOption;
+
+function isCustomPathOption(option: KernelOption): option is CustomPathOption {
+	return "isCustomPath" in option;
+}
+
+export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
+	private plugin: JupyMDPlugin;
+	private kernels: KernelInfo[] = [];
+	private isLoading = true;
+
+	constructor(app: App, plugin: JupyMDPlugin) {
+		super(app);
+		this.plugin = plugin;
+		this.setPlaceholder("Select a Python interpreter or type a custom path…");
+		this.setInstructions([
+			{command: "↑↓", purpose: "navigate"},
+			{command: "↵", purpose: "select"},
+			{command: "esc", purpose: "dismiss"},
+		]);
+	}
+
+	onOpen() {
+		super.onOpen();
+		this.addLoadingHint();
+		this.emptyStateText = "Type a Python path to use it directly.";
+		this.loadKernels();
+	}
+
+	private addLoadingHint() {
+		const promptEl = this.containerEl.querySelector(".prompt-results");
+		if (promptEl) {
+			const hint = promptEl.createEl("div", {
+				cls: "suggestion-empty",
+				text: "Discovering Python environments…",
+			});
+			hint.dataset.loadingHint = "true";
+		}
+	}
+
+	private removeLoadingHint() {
+		const hint = this.containerEl.querySelector('[data-loading-hint="true"]');
+		hint?.remove();
+	}
+
+	private async loadKernels() {
+		try {
+			this.kernels = await discoverKernels(this.app);
+		} catch (e) {
+			console.error("Kernel discovery failed:", e);
+			this.kernels = [];
+		} finally {
+			this.isLoading = false;
+			this.removeLoadingHint();
+			// Trigger re-render of the suggestion list
+			// @ts-ignore – internal Obsidian API
+			this.updateSuggestions();
+		}
+	}
+
+	getItems(): KernelOption[] {
+		return this.kernels;
+	}
+
+	getSuggestions(query: string): FuzzyMatch<KernelOption>[] {
+		const suggestions = super.getSuggestions(query);
+		const typed = query.trim();
+		if (!typed) return suggestions;
+
+		const normalizedTyped = typed.toLowerCase();
+		const hasExactPathMatch = this.kernels.some((kernel) => kernel.path.toLowerCase() === normalizedTyped);
+		if (hasExactPathMatch) return suggestions;
+
+		return [
+			{
+				item: {
+					label: `Use custom path: ${typed}`,
+					path: typed,
+					version: "Validate on select",
+					type: "system",
+					isCustomPath: true,
+				},
+				match: {
+					score: -1,
+					matches: [],
+				},
+			},
+			...suggestions,
+		];
+	}
+
+	getItemText(item: KernelOption): string {
+		// Used for fuzzy matching – include label, path and type so all are searchable
+		return `${item.label} ${item.version} ${item.path} ${item.type}`;
+	}
+
+	renderSuggestion(match: FuzzyMatch<KernelOption>, el: HTMLElement) {
+		const item = match.item;
+
+		const wrapper = el.createDiv({cls: "kernel-suggestion"});
+
+		const topRow = wrapper.createDiv({cls: "kernel-suggestion-top"});
+		topRow.createSpan({cls: "kernel-suggestion-label", text: item.label});
+		topRow.createSpan({
+			cls: `kernel-suggestion-badge ${isCustomPathOption(item) ? "kernel-badge-custom" : `kernel-badge-${item.type}`}`,
+			text: isCustomPathOption(item) ? "custom" : TYPE_BADGE[item.type],
+		});
+
+		const bottomRow = wrapper.createDiv({cls: "kernel-suggestion-bottom"});
+		bottomRow.createSpan({cls: "kernel-suggestion-version", text: item.version});
+		bottomRow.createSpan({cls: "kernel-suggestion-path", text: item.path});
+	}
+
+	async onChooseItem(item: KernelOption) {
+		if (isCustomPathOption(item)) {
+			const valid = await validatePythonPath(item.path);
+			if (!valid) {
+				new Notice(`Invalid Python path: ${item.path}`);
+				return;
+			}
+
+			await this.plugin.updateInterpreter(item.path);
+			new Notice(`Python kernel set to: ${item.path}`);
+			return;
+		}
+
+		await this.plugin.updateInterpreter(item.path);
+		new Notice(`Python kernel set to: ${item.label} (${item.version})`);
+	}
+}

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -3,7 +3,6 @@ import {CodeExecutor} from "./CodeExecutor";
 import JupyMDPlugin from "../main";
 import {validatePythonPath} from "../utils/pythonPathUtils";
 import {installLibs} from "../utils/helpers";
-import {runQuickSetup} from "../utils/quickSetup";
 import {KernelSelectorModal} from "./KernelSelector";
 
 export class JupyMDSettingTab extends PluginSettingTab {
@@ -17,27 +16,6 @@ export class JupyMDSettingTab extends PluginSettingTab {
 	display(): void {
 		const {containerEl} = this;
 		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName("Quick setup")
-			.setDesc("Automatically create a virtual environment (.jupymd) in your vault root and install the required libraries. Requires restart to take effect.")
-			.addButton((btn) => {
-				btn.setButtonText("Run")
-					.setCta()
-					.onClick(async () => {
-						btn.setDisabled(true);
-						btn.setButtonText("Setting up...");
-
-						const success = await runQuickSetup(this.app, this.plugin);
-
-						btn.setDisabled(false);
-						btn.setButtonText(success ? "Setup Complete" : "Run Quick Setup");
-
-						if (success) {
-							this.display();
-						}
-					});
-			});
 
 		const desc = document.createDocumentFragment();
 		desc.appendText("Select the Python interpreter.");

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -42,10 +42,8 @@ export class JupyMDSettingTab extends PluginSettingTab {
 		const desc = document.createDocumentFragment();
 		desc.appendText("Select the Python interpreter.");
 		desc.createEl("br");
-		desc.createEl("a", {
-			text: "Read manual setup guide.",
-			href: "https://github.com/d-eniz/jupymd/blob/master/README.md#manual-setup",
-		});
+		desc.createEl("strong", { text: "Current interpreter:" });
+		desc.appendText(` ${this.plugin.settings.pythonInterpreter || "No interpreter selected"}`);
 
 		const interpreterSetting = new Setting(containerEl)
 			.setName("Python interpreter")
@@ -57,13 +55,6 @@ export class JupyMDSettingTab extends PluginSettingTab {
 						new KernelSelectorModal(this.app, this.plugin).open();
 					});
 			});
-
-		interpreterSetting.controlEl.prepend(
-			createDiv({
-				cls: "jupymd-interpreter-display",
-				text: this.plugin.settings.pythonInterpreter || "No interpreter selected",
-			})
-		);
 
 		new Setting(containerEl)
 			.setName("Install required libraries")

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -3,6 +3,7 @@ import {CodeExecutor} from "./CodeExecutor";
 import JupyMDPlugin from "../main";
 import {validatePythonPath} from "../utils/pythonPathUtils";
 import {installLibs} from "../utils/helpers";
+import {runQuickSetup} from "../utils/quickSetup";
 import {KernelSelectorModal} from "./KernelSelector";
 
 export class JupyMDSettingTab extends PluginSettingTab {
@@ -16,6 +17,27 @@ export class JupyMDSettingTab extends PluginSettingTab {
 	display(): void {
 		const {containerEl} = this;
 		containerEl.empty();
+
+		new Setting(containerEl)
+			.setName("Quick setup")
+			.setDesc("Automatically create a virtual environment (.jupymd) in your vault root and install the required libraries. Requires restart to take effect.")
+			.addButton((btn) => {
+				btn.setButtonText("Run")
+					.setCta()
+					.onClick(async () => {
+						btn.setDisabled(true);
+						btn.setButtonText("Setting up...");
+
+						const success = await runQuickSetup(this.app, this.plugin);
+
+						btn.setDisabled(false);
+						btn.setButtonText(success ? "Setup Complete" : "Run Quick Setup");
+
+						if (success) {
+							this.display();
+						}
+					});
+			});
 
 		const desc = document.createDocumentFragment();
 		desc.appendText("Select the Python interpreter.");

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -4,15 +4,14 @@ import JupyMDPlugin from "../main";
 import {validatePythonPath} from "../utils/pythonPathUtils";
 import {installLibs} from "../utils/helpers";
 import {runQuickSetup} from "../utils/quickSetup";
+import {KernelSelectorModal} from "./KernelSelector";
 
 export class JupyMDSettingTab extends PluginSettingTab {
 	plugin: JupyMDPlugin;
-	executor: CodeExecutor;
 
 	constructor(app: App, plugin: JupyMDPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
-		this.executor = new CodeExecutor(this.plugin, this.plugin.settings.pythonInterpreter, this.app);
 	}
 
 	display(): void {
@@ -41,34 +40,30 @@ export class JupyMDSettingTab extends PluginSettingTab {
 			});
 
 		const desc = document.createDocumentFragment();
-		desc.appendText("Select the Python interpreter. Requires restart to take effect.");
+		desc.appendText("Select the Python interpreter.");
 		desc.createEl("br");
 		desc.createEl("a", {
 			text: "Read manual setup guide.",
 			href: "https://github.com/d-eniz/jupymd/blob/master/README.md#manual-setup",
 		});
 
-		new Setting(containerEl)
+		const interpreterSetting = new Setting(containerEl)
 			.setName("Python interpreter")
 			.setDesc(desc)
-			.addText((text) => {
-				text.setValue(this.plugin.settings.pythonInterpreter)
-				text.setPlaceholder("python3")
-				text.onChange(async (value) => {
-					const cleaned = value.trim();
-					const valid = await validatePythonPath(cleaned);
-					if (cleaned && !valid) {
-						new Notice("Invalid Python path")
-						return;
-					}
-					if (valid) {
-						new Notice("Valid Python path, saving interpreter location...")
-					}
+			.addButton((btn) => {
+				btn.setButtonText("Select interpreter")
+					.setCta()
+					.onClick(() => {
+						new KernelSelectorModal(this.app, this.plugin).open();
+					});
+			});
 
-					this.plugin.settings.pythonInterpreter = cleaned;
-					await this.plugin.saveSettings();
-				})
+		interpreterSetting.controlEl.prepend(
+			createDiv({
+				cls: "jupymd-interpreter-display",
+				text: this.plugin.settings.pythonInterpreter || "No interpreter selected",
 			})
+		);
 
 		new Setting(containerEl)
 			.setName("Install required libraries")

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import {Plugin, TFile, TAbstractFile, MarkdownView} from "obsidian";
 import {JupyMDSettingTab} from "./components/Settings";
 import {CodeExecutor} from "./components/CodeExecutor";
 import {FileSync} from "./components/FileSync";
+import {KernelSelectorModal} from "./components/KernelSelector";
 import {DEFAULT_SETTINGS, JupyMDPluginSettings} from "./components/types";
 import {registerCommands} from "./commands";
 import {createRoot} from "react-dom/client";
@@ -15,6 +16,8 @@ export default class JupyMDPlugin extends Plugin {
 	executor: CodeExecutor;
 	fileSync: FileSync;
 	currentNotePath: string | null = null;
+	private kernelStatusBarItem : HTMLElement;
+	private settingTab : JupyMDSettingTab;
 
 	async onload() {
 		await this.loadSettings();
@@ -26,6 +29,14 @@ export default class JupyMDPlugin extends Plugin {
 
 		this.executor = new CodeExecutor(this, this.settings.pythonInterpreter, this.app);
 		this.fileSync = new FileSync(this.app, this.settings.pythonInterpreter, this.settings);
+
+		this.kernelStatusBarItem = this.addStatusBarItem();
+		this.kernelStatusBarItem.addClass("jupymd-kernel-status");
+		void this.updateStatusBar();
+		this.kernelStatusBarItem.addEventListener("click", () => {
+			this.openKernelSelector();
+		});
+
 
 		registerCommands(this);
 
@@ -79,6 +90,21 @@ export default class JupyMDPlugin extends Plugin {
 					} catch (e) {
 						console.error("Failed to rename paired notebook:", e);
 					}
+				}
+			})
+		);
+
+		this.registerEvent(
+			this.app.workspace.on("file-open", () => {
+				void this.updateStatusBar();
+			})
+		);
+
+		this.registerEvent(
+			this.app.metadataCache.on("changed", (file) => {
+				const activeFile = this.app.workspace.getActiveFile();
+				if (activeFile && activeFile.path === file.path) {
+					void this.updateStatusBar();
 				}
 			})
 		);
@@ -164,5 +190,42 @@ export default class JupyMDPlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	private async updateStatusBar(): Promise<void> {
+		if (!this.kernelStatusBarItem) return;
+
+		const activeFile = this.app.workspace.getActiveFile();
+		if (!(activeFile instanceof TFile)) {
+			this.kernelStatusBarItem.hide();
+			return;
+		}
+
+		const isPaired = await isNotebookPaired(this.app, activeFile);
+		if (!isPaired) {
+			this.kernelStatusBarItem.hide();
+			return;
+		}
+
+		const interpreter = this.settings.pythonInterpreter ? this.settings.pythonInterpreter : "No interpreter";
+		this.kernelStatusBarItem.show();
+		this.kernelStatusBarItem.setText(interpreter);
+		this.kernelStatusBarItem.setAttr("aria-label", `Current Python interpreter: ${interpreter} — click to change`);
+	}
+
+	async updateInterpreter(newPath: string): Promise<void> {
+		this.settings.pythonInterpreter = newPath;
+		await this.saveSettings();
+
+		this.executor.cleanup();
+		this.executor = new CodeExecutor(this, newPath, this.app);
+		this.fileSync = new FileSync(this.app, newPath, this.settings);
+
+		await this.updateStatusBar();
+		this.settingTab?.display();
+	}
+
+	openKernelSelector(): void {
+		new KernelSelectorModal(this.app, this).open();
 	}
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,8 +8,10 @@ import {registerCommands} from "./commands";
 import {createRoot} from "react-dom/client";
 import {PythonCodeBlock} from "./components/CodeBlock";
 import {getAbsolutePath, isNotebookPaired} from "./utils/helpers";
+import {discoverKernels} from "./utils/kernelDiscovery";
 import {getDefaultPythonPath} from "./utils/pythonPathUtils";
 import * as fs from "fs";
+import * as path from "path";
 
 export default class JupyMDPlugin extends Plugin {
 	settings: JupyMDPluginSettings;
@@ -192,6 +194,16 @@ export default class JupyMDPlugin extends Plugin {
 		await this.saveData(this.settings);
 	}
 
+	private async formatInterpreterForStatusBar(interpreter: string): Promise<string> {
+		const kernels = await discoverKernels(this.app);
+		const match = kernels.find((kernel) => kernel.path === interpreter);
+		if (match) {
+			return match.label;
+		}
+
+		return path.basename(interpreter) || interpreter;
+	}
+
 	private async updateStatusBar(): Promise<void> {
 		if (!this.kernelStatusBarItem) return;
 
@@ -208,8 +220,9 @@ export default class JupyMDPlugin extends Plugin {
 		}
 
 		const interpreter = this.settings.pythonInterpreter ? this.settings.pythonInterpreter : "No interpreter";
+		const statusText = await this.formatInterpreterForStatusBar(interpreter);
 		this.kernelStatusBarItem.show();
-		this.kernelStatusBarItem.setText(interpreter);
+		this.kernelStatusBarItem.setText(statusText);
 		this.kernelStatusBarItem.setAttr("aria-label", `Current Python interpreter: ${interpreter} — click to change`);
 	}
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -37,10 +37,10 @@ export default class JupyMDPlugin extends Plugin {
 			this.openKernelSelector();
 		});
 
-
 		registerCommands(this);
 
-		this.addSettingTab(new JupyMDSettingTab(this.app, this));
+		this.settingTab = new JupyMDSettingTab(this.app, this);
+		this.addSettingTab(this.settingTab);
 
 		this.registerEvent(
 			this.app.vault.on("modify", async (file: TAbstractFile) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -31,7 +31,7 @@ export default class JupyMDPlugin extends Plugin {
 		this.fileSync = new FileSync(this.app, this.settings.pythonInterpreter, this.settings);
 
 		this.kernelStatusBarItem = this.addStatusBarItem();
-		this.kernelStatusBarItem.addClass("jupymd-kernel-status");
+		this.kernelStatusBarItem.addClass("kernel-status");
 		void this.updateStatusBar();
 		this.kernelStatusBarItem.addEventListener("click", () => {
 			this.openKernelSelector();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import {Plugin, TFile, TAbstractFile, MarkdownView} from "obsidian";
+import {Plugin, TFile, TAbstractFile, MarkdownView, setTooltip} from "obsidian";
 import {JupyMDSettingTab} from "./components/Settings";
 import {CodeExecutor} from "./components/CodeExecutor";
 import {FileSync} from "./components/FileSync";
@@ -223,7 +223,8 @@ export default class JupyMDPlugin extends Plugin {
 		const statusText = await this.formatInterpreterForStatusBar(interpreter);
 		this.kernelStatusBarItem.show();
 		this.kernelStatusBarItem.setText(statusText);
-		this.kernelStatusBarItem.setAttr("aria-label", `Current Python interpreter: ${interpreter} — click to change`);
+		setTooltip(this.kernelStatusBarItem, `Current Python interpreter: ${interpreter} — click to change`, {placement: "top"});
+		
 	}
 
 	async updateInterpreter(newPath: string): Promise<void> {

--- a/src/utils/kernelDiscovery.ts
+++ b/src/utils/kernelDiscovery.ts
@@ -1,0 +1,106 @@
+import * as path from "path";
+import {exec} from "child_process";
+import {promisify} from "util";
+import {App, FileSystemAdapter, Platform} from "obsidian";
+import {validatePythonPath} from "./pythonPathUtils";
+
+const execAsync = promisify(exec);
+
+export type KernelInfo = {
+	label: string;
+	path: string;
+	version: string;
+	type: "venv" | "system";
+};
+
+function getVaultBasePath(app: App): string | null {
+	const adapter = app.vault.adapter;
+	if (adapter instanceof FileSystemAdapter) {
+		return adapter.getBasePath();
+	}
+	return null;
+}
+
+async function getPythonVersion(pythonPath: string): Promise<string> {
+	try {
+		const {stdout, stderr} = await execAsync(`"${pythonPath}" --version`, {timeout: 3000});
+		const output = (stdout || stderr).trim();
+		const match = output.match(/Python\s+(\S+)/i);
+		return match ? match[1] : "unknown";
+	} catch {
+		return "unknown";
+	}
+}
+
+async function probeInterpreter(
+	pythonPath: string,
+	label: string,
+	type: "venv" | "system"
+): Promise<KernelInfo | null> {
+	const valid = await validatePythonPath(pythonPath);
+	if (!valid) return null;
+
+	const version = await getPythonVersion(pythonPath);
+	return {label, path: pythonPath, version, type};
+}
+
+async function discoverVaultVenv(app: App): Promise<KernelInfo[]> {
+	const basePath = getVaultBasePath(app);
+	if (!basePath) return [];
+
+	const pythonBin = Platform.isWin
+		? path.join(basePath, ".jupymd", "Scripts", "python.exe")
+		: path.join(basePath, ".jupymd", "bin", "python");
+
+	const result = await probeInterpreter(pythonBin, ".jupymd (vault venv)", "venv");
+	return result ? [result] : [];
+}
+
+function getGlobalInterpreterCandidates(): string[] {
+	const candidates = Platform.isWin
+		? [
+			"python",
+			"python3",
+			path.join(process.env.LOCALAPPDATA || "", "Programs", "Python", "Python313", "python.exe"),
+			path.join(process.env.LOCALAPPDATA || "", "Programs", "Python", "Python312", "python.exe"),
+		]
+		: [
+			"python3",
+			"python",
+			"/usr/bin/python3",
+			"/usr/local/bin/python3",
+			"/bin/python3",
+			"/usr/bin/python",
+			"/usr/local/bin/python",
+			"/opt/homebrew/bin/python3",
+			"/opt/homebrew/bin/python",
+		];
+
+	return candidates;
+}
+
+async function discoverGlobalInterpreters(): Promise<KernelInfo[]> {
+	const results: KernelInfo[] = [];
+
+	for (const candidate of getGlobalInterpreterCandidates()) {
+		const label = path.isAbsolute(candidate) ? path.basename(candidate) : candidate;
+		const result = await probeInterpreter(candidate, label, "system");
+		if (result) {
+			results.push(result);
+		}
+	}
+
+	return results;
+}
+
+export async function discoverKernels(app: App): Promise<KernelInfo[]> {
+	const [vaultVenv, globals] = await Promise.all([
+		discoverVaultVenv(app),
+		discoverGlobalInterpreters(),
+	]);
+
+	return [
+		...vaultVenv,
+		...globals,
+	];
+}

--- a/styles.css
+++ b/styles.css
@@ -201,3 +201,72 @@
 	border: none;
 	box-shadow: none;
 }
+
+.kernel-status {
+	cursor: pointer;
+	font-size: var(--font-ui-small);
+	opacity: 0.85;
+}
+
+.kernel-status:hover {
+	opacity: 1;
+}
+
+.kernel-suggestion {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 2px 0;
+}
+
+.kernel-suggestion-top,
+.kernel-suggestion-bottom {
+	display: flex;
+	align-items: center;
+}
+
+.kernel-suggestion-top {
+	gap: 6px;
+}
+
+.kernel-suggestion-bottom {
+	gap: 8px;
+	font-size: 0.8em;
+	color: var(--text-muted);
+}
+
+.kernel-suggestion-label,
+.kernel-suggestion-version {
+	font-weight: 500;
+}
+
+.kernel-suggestion-badge {
+	font-size: 0.7em;
+	padding: 1px 5px;
+	border-radius: 3px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	font-weight: 600;
+	background-color: var(--background-modifier-border);
+	color: var(--text-muted);
+}
+
+.kernel-badge-venv { background-color: rgba(80, 160, 255, 0.18); color: #5090e0; }
+.kernel-badge-system { background-color: rgba(140, 120, 220, 0.18); color: #8070c0; }
+.kernel-badge-custom { background-color: rgba(230, 150, 60, 0.16); color: #c67a18; }
+
+.jupymd-interpreter-display,
+.kernel-suggestion-path {
+	font-size: var(--font-ui-small);
+}
+
+.jupymd-interpreter-display {
+	color: var(--text-muted);
+	font-family: var(--font-monospace);
+}
+
+.kernel-suggestion-path {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}


### PR DESCRIPTION
**Key changes:**

**1. Kernel (Interpreter) Selection Modal and Discovery**
- Adds a new `KernelSelectorModal` (`src/components/KernelSelector.ts`) that lets users search, select, or enter a custom Python interpreter with validation and clear labels for environment type (system, venv, or custom).
- Implements `discoverKernels` utility (`src/utils/kernelDiscovery.ts`) to automatically find available Python interpreters in the vault and system, including version and type detection.

**2. Improved User Interface for Interpreter Selection**
- Replaces the plain text input in the settings tab with a button that opens the new kernel selector modal, and displays the currently selected interpreter in a styled, read-only field.
- Adds styled UI components for the kernel selector and interpreter display, including badges for environment type and improved suggestion formatting.

**3. Status Bar Integration**
- Adds a status bar item showing the current Python interpreter when working with paired notebooks; clicking it opens the kernel selector for quick changes. Status bar updates automatically on file or metadata changes.

**4. Command Palette and Command Registration**
- Registers a new command, "Select Python kernel", to open the kernel selector from the command palette.

These changes make it much easier and more intuitive for users to select, validate, and switch Python interpreters, while providing clear feedback and a modern UI.