### PR TITLE
Integrate virtual environment creator in interpreter context manager

### DIFF
--- a/src/components/CreateVenvModal.ts
+++ b/src/components/CreateVenvModal.ts
@@ -1,0 +1,135 @@
+import {App, Modal, Notice, Setting} from "obsidian";
+import {discoverKernels, KernelInfo} from "../utils/kernelDiscovery";
+
+export type CreateVenvResult = {
+	basePythonPath: string;
+	envName: string;
+};
+
+export class CreateVenvModal extends Modal {
+	private readonly initialPythonPath: string;
+	private basePythonPath: string;
+	private envName = ".jupymd";
+	private availableKernels: KernelInfo[] = [];
+	private resolver: ((result: CreateVenvResult | null) => void) | null = null;
+
+	constructor(app: App, initialPythonPath: string) {
+		super(app);
+		this.initialPythonPath = initialPythonPath;
+		this.basePythonPath = initialPythonPath;
+	}
+
+	openAndGetValue(): Promise<CreateVenvResult | null> {
+		return new Promise((resolve) => {
+			this.resolver = resolve;
+			this.open();
+		});
+	}
+
+	onOpen() {
+		const {contentEl} = this;
+		this.setTitle("Create virtual environment");
+		contentEl.empty();
+
+		new Setting(contentEl)
+			.setName("Base interpreter")
+			.setDesc("Python executable used to create the virtual environment.")
+			.addDropdown((dropdown) => {
+				dropdown.addOption("", "Loading interpreters…");
+				dropdown.setDisabled(true);
+				void this.loadInterpreterOptions(dropdown);
+			});
+
+		new Setting(contentEl)
+			.setName("Environment name")
+			.setDesc("This folder will be created in the vault root.")
+			.addText((text) => {
+				text.setPlaceholder(".jupymd");
+				text.setValue(this.envName)
+					.onChange((value) => {
+						this.envName = value.trim();
+					});
+			});
+
+		new Setting(contentEl)
+			.addButton((btn) => {
+				btn.setButtonText("Create")
+					.setCta()
+					.onClick(async () => {
+						const basePythonPath = this.basePythonPath.trim();
+						const envName = this.envName.trim();
+
+						if (!basePythonPath) {
+							new Notice("Enter a Python interpreter path.");
+							return;
+						}
+
+						if (!envName) {
+							new Notice("Enter an environment name.");
+							return;
+						}
+
+						if (/[\\/]/.test(envName)) {
+							new Notice("Environment name should be a single folder name, not a path.");
+							return;
+						}
+
+						if (!basePythonPath) {
+							new Notice("Select a base interpreter.");
+							return;
+						}
+
+						this.resolver?.({basePythonPath, envName});
+						this.resolver = null;
+						this.close();
+					});
+			})
+			.addButton((btn) => {
+				btn.setButtonText("Cancel")
+					.onClick(() => {
+						this.close();
+					});
+			});
+	}
+
+	onClose() {
+		this.contentEl.empty();
+		if (this.resolver) {
+			this.resolver(null);
+			this.resolver = null;
+		}
+	}
+
+	private async loadInterpreterOptions(dropdown: import("obsidian").DropdownComponent) {
+		try {
+			this.availableKernels = (await discoverKernels(this.app))
+				.filter((kernel) => kernel.type === "system");
+		} catch (error) {
+			console.error("Failed to discover interpreters for venv creation:", error);
+			this.availableKernels = [];
+		}
+
+		dropdown.selectEl.empty();
+
+		if (this.availableKernels.length === 0) {
+			dropdown.addOption("", "No interpreters found");
+			dropdown.setDisabled(true);
+			return;
+		}
+
+		for (const kernel of this.availableKernels) {
+			dropdown.addOption(kernel.path, `${kernel.label} (${kernel.version}) - ${kernel.path}`);
+		}
+
+		const initialValue = this.availableKernels.some((kernel) => kernel.path === this.initialPythonPath)
+			? this.initialPythonPath
+			: this.availableKernels[0].path;
+
+		this.basePythonPath = initialValue;
+		dropdown.setValue(initialValue);
+		dropdown.onChange((value) => {
+			this.basePythonPath = value;
+		});
+		dropdown.setDisabled(false);
+	}
+}

--- a/src/components/KernelSelector.ts
+++ b/src/components/KernelSelector.ts
@@ -1,5 +1,6 @@
 import {App, FuzzySuggestModal, FuzzyMatch, Notice} from "obsidian";
 import JupyMDPlugin from "../main";
+import {CreateVenvModal} from "./CreateVenvModal";
 import {discoverKernels, KernelInfo} from "../utils/kernelDiscovery";
 import {validatePythonPath} from "../utils/pythonPathUtils";
 import {runQuickSetup} from "../utils/quickSetup";
@@ -37,16 +38,12 @@ function isCreateVenvOption(option: KernelOption): option is CreateVenvOption {
 
 function createVenvOption(): CreateVenvOption {
 	return {
-		label: "Create virtual environment (.jupymd)",
-		path: "Create and select a vault-local environment",
-		version: "Recommended",
+		label: "Create virtual environment",
+		path: "Choose the base interpreter path and environment name",
+		version: "Setup",
 		type: "venv",
 		isCreateVenv: true,
 	};
-}
-
-function hasVaultVenv(kernels: KernelInfo[]): boolean {
-	return kernels.some((kernel) => kernel.label === ".jupymd (vault venv)");
 }
 
 export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
@@ -116,21 +113,20 @@ export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
 				matches: [],
 			},
 		};
-		const includeCreateOption = !hasVaultVenv(this.kernels);
 
 		const typed = query.trim();
 		if (!typed) {
-			return includeCreateOption ? [createOptionSuggestion, ...suggestions] : suggestions;
+			return [createOptionSuggestion, ...suggestions];
 		}
 
 		const normalizedTyped = typed.toLowerCase();
 		const hasExactPathMatch = this.kernels.some((kernel) => kernel.path.toLowerCase() === normalizedTyped);
 		if (hasExactPathMatch) {
-			return includeCreateOption ? [createOptionSuggestion, ...suggestions] : suggestions;
+			return [createOptionSuggestion, ...suggestions];
 		}
 
 		return [
-			...(includeCreateOption ? [createOptionSuggestion] : []),
+			createOptionSuggestion,
 			{
 				item: {
 					label: `Use custom path: ${typed}`,
@@ -172,7 +168,20 @@ export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
 
 	async onChooseItem(item: KernelOption) {
 		if (isCreateVenvOption(item)) {
-			const success = await runQuickSetup(this.app, this.plugin);
+			const config = await new CreateVenvModal(
+				this.app,
+				this.plugin.settings.pythonInterpreter
+			).openAndGetValue();
+			if (!config) {
+				return;
+			}
+
+			const success = await runQuickSetup(
+				this.app,
+				this.plugin,
+				config.basePythonPath,
+				config.envName
+			);
 			if (!success) {
 				return;
 			}

--- a/src/components/KernelSelector.ts
+++ b/src/components/KernelSelector.ts
@@ -2,6 +2,7 @@ import {App, FuzzySuggestModal, FuzzyMatch, Notice} from "obsidian";
 import JupyMDPlugin from "../main";
 import {discoverKernels, KernelInfo} from "../utils/kernelDiscovery";
 import {validatePythonPath} from "../utils/pythonPathUtils";
+import {runQuickSetup} from "../utils/quickSetup";
 
 const TYPE_BADGE: Record<KernelInfo["type"], string> = {
 	venv: "venv",
@@ -16,10 +17,36 @@ type CustomPathOption = {
 	isCustomPath: true;
 };
 
-type KernelOption = KernelInfo | CustomPathOption;
+type CreateVenvOption = {
+	label: string;
+	path: string;
+	version: string;
+	type: "venv";
+	isCreateVenv: true;
+};
+
+type KernelOption = KernelInfo | CustomPathOption | CreateVenvOption;
 
 function isCustomPathOption(option: KernelOption): option is CustomPathOption {
 	return "isCustomPath" in option;
+}
+
+function isCreateVenvOption(option: KernelOption): option is CreateVenvOption {
+	return "isCreateVenv" in option;
+}
+
+function createVenvOption(): CreateVenvOption {
+	return {
+		label: "Create virtual environment (.jupymd)",
+		path: "Create and select a vault-local environment",
+		version: "Recommended",
+		type: "venv",
+		isCreateVenv: true,
+	};
+}
+
+function hasVaultVenv(kernels: KernelInfo[]): boolean {
+	return kernels.some((kernel) => kernel.label === ".jupymd (vault venv)");
 }
 
 export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
@@ -82,14 +109,28 @@ export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
 
 	getSuggestions(query: string): FuzzyMatch<KernelOption>[] {
 		const suggestions = super.getSuggestions(query);
+		const createOptionSuggestion: FuzzyMatch<KernelOption> = {
+			item: createVenvOption(),
+			match: {
+				score: -2,
+				matches: [],
+			},
+		};
+		const includeCreateOption = !hasVaultVenv(this.kernels);
+
 		const typed = query.trim();
-		if (!typed) return suggestions;
+		if (!typed) {
+			return includeCreateOption ? [createOptionSuggestion, ...suggestions] : suggestions;
+		}
 
 		const normalizedTyped = typed.toLowerCase();
 		const hasExactPathMatch = this.kernels.some((kernel) => kernel.path.toLowerCase() === normalizedTyped);
-		if (hasExactPathMatch) return suggestions;
+		if (hasExactPathMatch) {
+			return includeCreateOption ? [createOptionSuggestion, ...suggestions] : suggestions;
+		}
 
 		return [
+			...(includeCreateOption ? [createOptionSuggestion] : []),
 			{
 				item: {
 					label: `Use custom path: ${typed}`,
@@ -120,8 +161,8 @@ export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
 		const topRow = wrapper.createDiv({cls: "kernel-suggestion-top"});
 		topRow.createSpan({cls: "kernel-suggestion-label", text: item.label});
 		topRow.createSpan({
-			cls: `kernel-suggestion-badge ${isCustomPathOption(item) ? "kernel-badge-custom" : `kernel-badge-${item.type}`}`,
-			text: isCustomPathOption(item) ? "custom" : TYPE_BADGE[item.type],
+			cls: `kernel-suggestion-badge ${isCustomPathOption(item) ? "kernel-badge-custom" : isCreateVenvOption(item) ? "kernel-badge-create" : `kernel-badge-${item.type}`}`,
+			text: isCustomPathOption(item) ? "custom" : isCreateVenvOption(item) ? "setup" : TYPE_BADGE[item.type],
 		});
 
 		const bottomRow = wrapper.createDiv({cls: "kernel-suggestion-bottom"});
@@ -130,6 +171,17 @@ export class KernelSelectorModal extends FuzzySuggestModal<KernelOption> {
 	}
 
 	async onChooseItem(item: KernelOption) {
+		if (isCreateVenvOption(item)) {
+			const success = await runQuickSetup(this.app, this.plugin);
+			if (!success) {
+				return;
+			}
+
+			this.kernels = await discoverKernels(this.app);
+			this.close();
+			return;
+		}
+
 		if (isCustomPathOption(item)) {
 			const valid = await validatePythonPath(item.path);
 			if (!valid) {

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -20,7 +20,7 @@ export class JupyMDSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("Quick setup")
-			.setDesc("Automatically create a virtual environment (.jupymd) in your vault root and install the required libraries. Requires restart to take effect.")
+			.setDesc("Automatically create a virtual environment (.jupymd) in your vault root and install the required libraries.")
 			.addButton((btn) => {
 				btn.setButtonText("Run")
 					.setCta()

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -42,10 +42,8 @@ export class JupyMDSettingTab extends PluginSettingTab {
 		const desc = document.createDocumentFragment();
 		desc.appendText("Select the Python interpreter.");
 		desc.createEl("br");
-		desc.createEl("a", {
-			text: "Read manual setup guide.",
-			href: "https://github.com/d-eniz/jupymd/blob/master/README.md#manual-setup",
-		});
+		desc.createEl("strong", { text: "Current interpreter:" });
+		desc.appendText(` ${this.plugin.settings.pythonInterpreter || "No interpreter selected"}`);
 
 		const interpreterSetting = new Setting(containerEl)
 			.setName("Python interpreter")
@@ -57,13 +55,6 @@ export class JupyMDSettingTab extends PluginSettingTab {
 						new KernelSelectorModal(this.app, this.plugin).open();
 					});
 			});
-
-		interpreterSetting.controlEl.prepend(
-			createDiv({
-				cls: "jupymd-interpreter-display",
-				text: this.plugin.settings.pythonInterpreter || "No interpreter selected",
-			})
-		);
 
 		new Setting(containerEl)
 			.setName("Install required libraries")

--- a/src/components/Settings.ts
+++ b/src/components/Settings.ts
@@ -3,7 +3,6 @@ import {CodeExecutor} from "./CodeExecutor";
 import JupyMDPlugin from "../main";
 import {validatePythonPath} from "../utils/pythonPathUtils";
 import {installLibs} from "../utils/helpers";
-import {runQuickSetup} from "../utils/quickSetup";
 import {KernelSelectorModal} from "./KernelSelector";
 
 export class JupyMDSettingTab extends PluginSettingTab {
@@ -17,27 +16,6 @@ export class JupyMDSettingTab extends PluginSettingTab {
 	display(): void {
 		const {containerEl} = this;
 		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName("Quick setup")
-			.setDesc("Automatically create a virtual environment (.jupymd) in your vault root and install the required libraries.")
-			.addButton((btn) => {
-				btn.setButtonText("Run")
-					.setCta()
-					.onClick(async () => {
-						btn.setDisabled(true);
-						btn.setButtonText("Setting up...");
-
-						const success = await runQuickSetup(this.app, this.plugin);
-
-						btn.setDisabled(false);
-						btn.setButtonText(success ? "Setup Complete" : "Run Quick Setup");
-
-						if (success) {
-							this.display();
-						}
-					});
-			});
 
 		const desc = document.createDocumentFragment();
 		desc.appendText("Select the Python interpreter.");

--- a/src/utils/kernelDiscovery.ts
+++ b/src/utils/kernelDiscovery.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as fs from "fs";
 import {exec} from "child_process";
 import {promisify} from "util";
 import {App, FileSystemAdapter, Platform} from "obsidian";
@@ -44,16 +45,42 @@ async function probeInterpreter(
 	return {label, path: pythonPath, version, type};
 }
 
-async function discoverVaultVenv(app: App): Promise<KernelInfo[]> {
+function getVenvPythonPath(envDir: string): string {
+	return Platform.isWin
+		? path.join(envDir, "Scripts", "python.exe")
+		: path.join(envDir, "bin", "python");
+}
+
+async function discoverVenvs(app: App): Promise<KernelInfo[]> {
 	const basePath = getVaultBasePath(app);
 	if (!basePath) return [];
 
-	const pythonBin = Platform.isWin
-		? path.join(basePath, ".jupymd", "Scripts", "python.exe")
-		: path.join(basePath, ".jupymd", "bin", "python");
+	const results: KernelInfo[] = [];
 
-	const result = await probeInterpreter(pythonBin, ".jupymd (vault venv)", "venv");
-	return result ? [result] : [];
+	try {
+		const entries = fs.readdirSync(basePath, {withFileTypes: true});
+		for (const entry of entries) {
+			if (!entry.isDirectory() || !entry.name.startsWith(".")) {
+				continue;
+			}
+
+			const envDir = path.join(basePath, entry.name);
+			const pyvenvCfgPath = path.join(envDir, "pyvenv.cfg");
+			if (!fs.existsSync(pyvenvCfgPath)) {
+				continue;
+			}
+
+			const pythonPath = getVenvPythonPath(envDir);
+			const result = await probeInterpreter(pythonPath, entry.name, "venv");
+			if (result) {
+				results.push(result);
+			}
+		}
+	} catch {
+		return [];
+	}
+
+	return results;
 }
 
 function getGlobalInterpreterCandidates(): string[] {
@@ -94,13 +121,13 @@ async function discoverGlobalInterpreters(): Promise<KernelInfo[]> {
 }
 
 export async function discoverKernels(app: App): Promise<KernelInfo[]> {
-	const [vaultVenv, globals] = await Promise.all([
-		discoverVaultVenv(app),
+	const [venvs, globals] = await Promise.all([
+		discoverVenvs(app),
 		discoverGlobalInterpreters(),
 	]);
 
 	return [
-		...vaultVenv,
+		...venvs,
 		...globals,
 	];
 }

--- a/src/utils/quickSetup.ts
+++ b/src/utils/quickSetup.ts
@@ -39,10 +39,9 @@ export async function runQuickSetup(app: App, plugin: JupyMDPlugin): Promise<boo
 		new Notice("Installing libraries...");
 		await installLibs(venvPythonPath, "jupytext matplotlib")
 
-		plugin.settings.pythonInterpreter = venvPythonPath;
-		await plugin.saveSettings();
+		await plugin.updateInterpreter(venvPythonPath);
 
-		new Notice("Quick setup complete! Virtual environment created successfully. Please restart Obsidian to apply changes.");
+		new Notice("Quick setup complete! Virtual environment created successfully.");
 		return true;
 	} catch (error: any) {
 		console.error("Quick setup failed:", error);

--- a/src/utils/quickSetup.ts
+++ b/src/utils/quickSetup.ts
@@ -9,7 +9,12 @@ import {getDefaultPythonPath} from "./pythonPathUtils";
 
 const execAsync = promisify(exec);
 
-export async function runQuickSetup(app: App, plugin: JupyMDPlugin): Promise<boolean> {
+export async function runQuickSetup(
+	app: App,
+	plugin: JupyMDPlugin,
+	basePythonPath?: string,
+	envNameInput?: string
+): Promise<boolean> {
 	const adapter = app.vault.adapter as any;
 	if (!adapter.getBasePath) {
 		new Notice("Quick setup is only supported on local file systems.");
@@ -17,12 +22,16 @@ export async function runQuickSetup(app: App, plugin: JupyMDPlugin): Promise<boo
 	}
 
 	const basePath = adapter.getBasePath();
-	const venvPath = path.join(basePath, ".jupymd");
+	let envName = envNameInput?.trim() || ".jupymd";
+	envName = envName.startsWith(".") ? envName : `.${envName}`;
+	const venvPath = path.join(basePath, envName);
 
 	new Notice("Creating virtual environment... Please wait.");
 
 	try {
-		const basePython = plugin.settings.pythonInterpreter || getDefaultPythonPath();
+		const basePython = basePythonPath?.trim()
+			|| plugin.settings.pythonInterpreter
+			|| getDefaultPythonPath();
 
 		await execAsync(`"${basePython}" -m venv "${venvPath}"`);
 
@@ -41,7 +50,7 @@ export async function runQuickSetup(app: App, plugin: JupyMDPlugin): Promise<boo
 
 		await plugin.updateInterpreter(venvPythonPath);
 
-		new Notice("Quick setup complete! Virtual environment created successfully.");
+		new Notice(`Quick setup complete! Virtual environment '${envName}' created successfully.`);
 		return true;
 	} catch (error: any) {
 		console.error("Quick setup failed:", error);

--- a/styles.css
+++ b/styles.css
@@ -254,6 +254,7 @@
 .kernel-badge-venv { background-color: rgba(80, 160, 255, 0.18); color: #5090e0; }
 .kernel-badge-system { background-color: rgba(140, 120, 220, 0.18); color: #8070c0; }
 .kernel-badge-custom { background-color: rgba(230, 150, 60, 0.16); color: #c67a18; }
+.kernel-badge-create { background-color: rgba(80, 190, 140, 0.18); color: #3d9a68; }
 
 .jupymd-interpreter-display,
 .kernel-suggestion-path {


### PR DESCRIPTION
As suggested in https://github.com/d-eniz/jupymd/pull/45#issuecomment-4232797481, users can now create a new virtual environment directly from the interpreter selection modal, choosing both the base interpreter and the environment name. The previous "Quick setup" button in settings has been removed. Additionally, the kernel discovery logic now detects all virtual environments in the vault root (not just `.jupymd`), and the UI has been updated to support these changes.

**New Virtual Environment Creation Workflow:**

* Added `CreateVenvModal` component, which allows users to select a base Python interpreter and specify a name for a new virtual environment. The modal validates input and integrates with the interpreter selection flow. (`src/components/CreateVenvModal.ts`)
* The kernel selector now includes a "Create virtual environment" option at the top of the list. Selecting it opens the new modal, and upon completion, runs the setup and refreshes the kernel list. (`src/components/KernelSelector.ts`) 
* Added a new badge style for the create-venv option in the kernel selector. (`styles.css`)

**Kernel Discovery Improvements:**

* The kernel discovery logic now lists all detected virtual environments (any folder in the vault root with a `pyvenv.cfg` file), not just the default `.jupymd` environment. (`src/utils/kernelDiscovery.ts`)